### PR TITLE
Format alarm notifications for readability

### DIFF
--- a/lambda/alarm_formatter.py
+++ b/lambda/alarm_formatter.py
@@ -1,0 +1,77 @@
+import json
+
+
+COMPARISON_SYMBOLS = {
+    "GreaterThanOrEqualToThreshold": ">=",
+    "GreaterThanThreshold": ">",
+    "LessThanOrEqualToThreshold": "<=",
+    "LessThanThreshold": "<",
+    "GreaterThanUpperThreshold": "> upper",
+    "LessThanLowerThreshold": "< lower",
+}
+
+
+def _format_period(seconds):
+    if seconds >= 3600:
+        return f"{seconds // 3600}h"
+    if seconds >= 60:
+        return f"{seconds // 60}m"
+    return f"{seconds}s"
+
+
+def format_alarm(sns_record):
+    """Parse an SNS record containing a CloudWatch alarm and return a formatted dict.
+
+    Returns:
+        dict with "title" (short summary) and "body" (detailed message).
+    """
+    sns_message = sns_record.get("Sns", {})
+    subject = sns_message.get("Subject", "")
+
+    try:
+        alarm = json.loads(sns_message.get("Message", "{}"))
+    except (json.JSONDecodeError, TypeError):
+        return {"title": subject or "Alarm Notification", "body": str(sns_message)}
+
+    alarm_name = alarm.get("AlarmName", "Unknown")
+    new_state = alarm.get("NewStateValue", "Unknown")
+    old_state = alarm.get("OldStateValue", "Unknown")
+    reason = alarm.get("NewStateReason", "")
+    state_change_time = alarm.get("StateChangeTime", "")
+
+    trigger = alarm.get("Trigger", {})
+    metric_name = trigger.get("MetricName", "Unknown")
+    dimensions = trigger.get("Dimensions", [])
+    threshold = trigger.get("Threshold")
+    comparison = trigger.get("ComparisonOperator", "")
+    statistic = trigger.get("Statistic", "")
+    period = trigger.get("Period", 0)
+    datapoints_to_alarm = trigger.get("DatapointsToAlarm", "")
+    evaluation_periods = trigger.get("EvaluationPeriods", "")
+    treat_missing = trigger.get("TreatMissingData", "")
+
+    # Format dimensions as "Value (Name)" pairs
+    dims_parts = [
+        f"{d.get('value', '?')} ({d.get('name', '?')})"
+        for d in dimensions
+    ]
+    dims_str = ", ".join(dims_parts) if dims_parts else "None"
+
+    comp_symbol = COMPARISON_SYMBOLS.get(comparison, comparison)
+    period_str = _format_period(period)
+
+    title = f"{new_state}: {alarm_name}"
+
+    body_lines = [
+        f"State:     {old_state} -> {new_state}",
+        f"Time:      {state_change_time}",
+        f"Reason:    {reason}",
+        f"",
+        f"Metric:    {metric_name}",
+        f"Device:    {dims_str}",
+        f"Condition: {statistic} {comp_symbol} {threshold}",
+        f"Period:    {period_str} ({datapoints_to_alarm}/{evaluation_periods} datapoints)",
+        f"Missing:   treated as {treat_missing}",
+    ]
+
+    return {"title": title, "body": "\n".join(body_lines)}

--- a/lambda/nepenthes_alarm_email_formatter.py
+++ b/lambda/nepenthes_alarm_email_formatter.py
@@ -1,0 +1,26 @@
+import json
+import os
+import boto3
+
+from alarm_formatter import format_alarm
+
+FORMATTED_TOPIC_ARN = os.environ["FORMATTED_TOPIC_ARN"]
+sns_client = boto3.client("sns")
+
+
+def lambda_handler(event, _):
+    print("Event: " + str(event))
+
+    record = event.get("Records", [{}])[0]
+    formatted = format_alarm(record)
+
+    response = sns_client.publish(
+        TopicArn=FORMATTED_TOPIC_ARN,
+        Subject=formatted["title"][:100],  # SNS subject max 100 chars
+        Message=formatted["body"],
+    )
+
+    return {
+        'statusCode': 200,
+        'body': json.dumps(response, default=str),
+    }

--- a/lambda/nepenthes_pushover.py
+++ b/lambda/nepenthes_pushover.py
@@ -2,30 +2,27 @@ import json
 import os
 import requests
 
+from alarm_formatter import format_alarm
+
 PUSHOVER_API_KEY = os.environ["PUSHOVER_API_KEY"]
 PAGEE_USER_KEY = os.environ["PAGEE_USER_KEY"]
 API_URL = "https://api.pushover.net/1/messages.json"
 
-def _default(o):
-    if hasattr(o, "astimezone") and hasattr(o, "isoformat"):
-        return o.astimezone().isoformat()
-    else:
-        return str(o)
-
-def _parse_message(event):
-    return json.dumps({
-        "Event": event,
-    }, indent=4, sort_keys=True, default=_default)
 
 def lambda_handler(event, _):
     print("Event: " + str(event))
+
+    record = event.get("Records", [{}])[0]
+    formatted = format_alarm(record)
+
     headers = {
         'content-type': 'application/x-www-form-urlencoded',
     }
     data = {
         "token": PUSHOVER_API_KEY,
         "user": PAGEE_USER_KEY,
-        "message": _parse_message(event),
+        "title": formatted["title"],
+        "message": formatted["body"],
         "priority": 2, # Critical Alert
         "retry": 120, # 2min
         "expire": 900, # 15min

--- a/lib/lambda-functions.ts
+++ b/lib/lambda-functions.ts
@@ -9,6 +9,7 @@ export class LambdaFunctions {
 
     public nepenthesLogPullerFunction: lambda.Function;
     public nepenthesPushoverFunction: lambda.Function;
+    public nepenthesAlarmEmailFormatterFunction: lambda.Function;
     public nepenthesOnlinePlugStatusFunction: lambda.Function;
     public nepenthesPiPlugOnFunction: lambda.Function;
 
@@ -48,6 +49,17 @@ export class LambdaFunctions {
             }),
             retryAttempts: 1,
             layers: [requestsLayer3_12],
+        });
+
+        this.nepenthesAlarmEmailFormatterFunction = new lambda.Function(scope, 'NAlarmEmailFormatterLambda', {
+            runtime: lambda.Runtime.PYTHON_3_12,
+            handler: 'nepenthes_alarm_email_formatter.lambda_handler',
+            code: lambdaCode,
+            logGroup: new logs.LogGroup(scope, 'NAlarmEmailFormatterLogGroup', {
+                retention: logs.RetentionDays.TWO_MONTHS,
+                removalPolicy: RemovalPolicy.DESTROY,
+            }),
+            retryAttempts: 1,
         });
 
         this.nepenthesOnlinePlugStatusFunction = new lambda.Function(scope, "NOnlinePlugStatusLambda", {


### PR DESCRIPTION
Raw CloudWatch alarm JSON was hard to read in both email and Pushover
notifications. Add a shared alarm_formatter module that parses the
alarm payload into a human-readable format with state, reason, metric
details, and threshold info.

- Update Pushover Lambda to send formatted title + body
- Add email formatter Lambda that republishes formatted messages
  to a new SNS topic for email delivery
- Replace raw email-json subscription with formatted email flow

https://claude.ai/code/session_01VpfPsb8XCmojuA6EHwpLnE