### PR TITLE
Switch Lambdas to ARM64 and bundle deps, drop Klayers

### DIFF
--- a/lambda/pyproject.toml
+++ b/lambda/pyproject.toml
@@ -2,6 +2,9 @@
 name = "nepenthes-lambda"
 version = "0.1.0"
 requires-python = ">=3.12"
+dependencies = [
+    "requests",
+]
 
 [dependency-groups]
 dev = [
@@ -9,7 +12,6 @@ dev = [
     "pytest-cov",
     "moto[cloudwatch]",
     "boto3",
-    "requests",
 ]
 
 [tool.pytest.ini_options]

--- a/lambda/uv.lock
+++ b/lambda/uv.lock
@@ -425,6 +425,9 @@ wheels = [
 name = "nepenthes-lambda"
 version = "0.1.0"
 source = { virtual = "." }
+dependencies = [
+    { name = "requests" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -432,10 +435,10 @@ dev = [
     { name = "moto" },
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "requests" },
 ]
 
 [package.metadata]
+requires-dist = [{ name = "requests" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -443,7 +446,6 @@ dev = [
     { name = "moto", extras = ["cloudwatch"] },
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "requests" },
 ]
 
 [[package]]

--- a/test/nepenthes_cdk.test.ts
+++ b/test/nepenthes_cdk.test.ts
@@ -70,14 +70,20 @@ describe('Lambda Functions', () => {
         });
     });
 
-    test('functions that need requests use the requests layer', () => {
+    test('all functions use ARM64 architecture', () => {
         const functions = template.findResources('AWS::Lambda::Function');
-        const withLayer = Object.values(functions).filter((resource) => {
+        for (const [, resource] of Object.entries(functions)) {
             const props = resource.Properties as Record<string, unknown>;
-            return Array.isArray(props.Layers) &&
-                (props.Layers as string[]).includes('arn:aws:lambda:us-west-2:770693421928:layer:Klayers-p312-requests:2');
-        });
-        expect(withLayer.length).toBe(4);
+            expect(props.Architectures).toEqual(['arm64']);
+        }
+    });
+
+    test('no functions use external Lambda layers', () => {
+        const functions = template.findResources('AWS::Lambda::Function');
+        for (const [, resource] of Object.entries(functions)) {
+            const props = resource.Properties as Record<string, unknown>;
+            expect(props.Layers).toBeUndefined();
+        }
     });
 });
 


### PR DESCRIPTION
## Summary
- All 5 Lambda functions now use ARM64 (Graviton2) for ~20% cost reduction
- Replaced the third-party Klayers `requests` layer with bundled dependencies using CDK asset bundling (local pip fallback + Docker for CI)
- Moved `requests` from dev to project dependencies in `pyproject.toml`
- Eliminates external dependency risk from Klayers layer deprecation

## Test plan
- [x] CDK tests pass — verifies ARM64 architecture on all functions and no external layers
- [x] Python tests pass (57 tests, 99.56% coverage)
- [ ] Verify Lambda functions execute correctly on ARM64 after deploy

https://claude.ai/code/session_0164rVH1oNDYAiwbzRpZEQnV