### PR TITLE
Add cdk-nag for security and best practice scanning

### DIFF
--- a/bin/nepenthes_cdk.ts
+++ b/bin/nepenthes_cdk.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
+import { Aspects } from 'aws-cdk-lib';
+import { AwsSolutionsChecks } from 'cdk-nag';
 import { NepenthesCDKStack } from '../lib/nepenthes_cdk-stack';
 
 const app = new cdk.App();
@@ -19,3 +21,5 @@ new NepenthesCDKStack(app, 'NepenthesCDKStack', {
 
   /* For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html */
 });
+
+Aspects.of(app).add(new AwsSolutionsChecks());

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "aws-cdk-lib": "^2.238.0",
+        "cdk-nag": "^2.37.55",
         "constructs": "^10.4.5",
         "source-map-support": "^0.5.21"
       },
@@ -2283,6 +2284,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/cdk-nag": {
+      "version": "2.37.55",
+      "resolved": "https://registry.npmjs.org/cdk-nag/-/cdk-nag-2.37.55.tgz",
+      "integrity": "sha512-xcAkygwbph3pp7N0UEzJBmXUH/MIsluV7DYJSeZ/V3yCr0Y0QaRGO298WyD6mi4K+Rmnpl+EJoWUxcOblOqLKA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.176.0",
+        "constructs": "^10.0.5"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "aws-cdk-lib": "^2.238.0",
+    "cdk-nag": "^2.37.55",
     "constructs": "^10.4.5",
     "source-map-support": "^0.5.21"
   }


### PR DESCRIPTION
## Summary
- Adds `cdk-nag` package with `AwsSolutionsChecks` aspect applied to the CDK app
- Runs AWS Solutions security/best-practice rules during `cdk synth` and `cdk deploy`
- Catches issues like overly broad IAM policies, missing encryption, or missing logging before they reach production
- Zero runtime cost — checks run at synthesis time only

## Test plan
- [x] CDK tests pass (20 tests)
- [x] Build succeeds with cdk-nag integrated
- [ ] Review nag findings during first `cdk synth` and add suppressions for acceptable items

https://claude.ai/code/session_0164rVH1oNDYAiwbzRpZEQnV