### PR TITLE
Reduce EventBridge polling from */2 to */5 minutes

### DIFF
--- a/lib/nepenthes_cdk-stack.ts
+++ b/lib/nepenthes_cdk-stack.ts
@@ -38,7 +38,7 @@ export class NepenthesCDKStack extends cdk.Stack {
     cdk.aws_cloudwatch.Metric.grantPutMetricData(lambdaFunctions.nepenthesOnlinePlugStatusFunction.grantPrincipal);
 
     // Setup Schedule to run Online Plug Status Lambda Function per cron schedule
-    const onlineMetricSchedule = new cdk.aws_events.Rule(this, "NOnlineMetricRule", {schedule: cdk.aws_events.Schedule.cron({minute: "*/2"})});
+    const onlineMetricSchedule = new cdk.aws_events.Rule(this, "NOnlineMetricRule", {schedule: cdk.aws_events.Schedule.cron({minute: "*/5"})});
     onlineMetricSchedule.addTarget(new cdk.aws_events_targets.LambdaFunction(lambdaFunctions.nepenthesOnlinePlugStatusFunction));
 
     // Setup SNS to alarm

--- a/test/nepenthes_cdk.test.ts
+++ b/test/nepenthes_cdk.test.ts
@@ -106,9 +106,9 @@ describe('IoT Rule', () => {
 });
 
 describe('EventBridge', () => {
-    test('creates schedule rule with 2-minute cron', () => {
+    test('creates schedule rule with 5-minute cron', () => {
         template.hasResourceProperties('AWS::Events::Rule', {
-            ScheduleExpression: 'cron(*/2 * * * ? *)',
+            ScheduleExpression: 'cron(*/5 * * * ? *)',
         });
     });
 });


### PR DESCRIPTION
## Summary
- Changes the SwitchBot plug status check cron from every 2 minutes to every 5 minutes
- Reduces Lambda invocations by 60% (720 → 288/day), SwitchBot API calls, and CloudWatch PutMetricData calls proportionally
- Detection latency only increases marginally since the Pi offline alarm already uses 3×5-minute evaluation periods

## Test plan
- [x] CDK tests updated and passing (cron expression assertion changed to `*/5`)
- [ ] Verify CloudWatch alarms still trigger within acceptable time window after deploy

https://claude.ai/code/session_0164rVH1oNDYAiwbzRpZEQnV