### PR TITLE
Address cdk-nag findings: fix SNS SSL, upgrade runtime, tighten IAM

### DIFF
--- a/lib/nepenthes_cdk-stack.ts
+++ b/lib/nepenthes_cdk-stack.ts
@@ -1,7 +1,8 @@
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
+import { NagSuppressions } from 'cdk-nag';
 import { LambdaFunctions } from './lambda-functions';
-import { EMAIL_ADDRESS, METRIC_NAMESPACE, METRIC_NAME_VALID } from './constants';
+import { EMAIL_ADDRESS, METRIC_NAMESPACE } from './constants';
 import { NepenthesAlarms } from './nepenthes-alarms';
 import { NepenthesDashboard } from './nepenthes-dashboard';
 
@@ -34,9 +35,29 @@ export class NepenthesCDKStack extends cdk.Stack {
           sourceArn: logPullerTopicRule.attrArn,
         }
     );
-    // Grant Cloud watch put metric permission to relevant lambda functions
-    cdk.aws_cloudwatch.Metric.grantPutMetricData(lambdaFunctions.nepenthesLogPullerFunction.grantPrincipal);
-    cdk.aws_cloudwatch.Metric.grantPutMetricData(lambdaFunctions.nepenthesOnlinePlugStatusFunction.grantPrincipal);
+    // Grant CloudWatch PutMetricData scoped to our namespace
+    const putMetricPolicy = new cdk.aws_iam.PolicyStatement({
+      actions: ['cloudwatch:PutMetricData'],
+      resources: ['*'],
+      conditions: {
+        StringEquals: { 'cloudwatch:namespace': METRIC_NAMESPACE },
+      },
+    });
+    lambdaFunctions.nepenthesLogPullerFunction.role!.addToPrincipalPolicy(putMetricPolicy);
+    lambdaFunctions.nepenthesOnlinePlugStatusFunction.role!.addToPrincipalPolicy(putMetricPolicy);
+
+    // Suppress IAM5: log stream ARNs require logGroupArn:* suffix (tightest scope possible),
+    // and cloudwatch:PutMetricData does not support resource-level permissions (scoped by namespace condition)
+    NagSuppressions.addResourceSuppressionsByPath(this, [
+      `/${id}/NLogPullerRole/DefaultPolicy/Resource`,
+      `/${id}/NPushoverRole/DefaultPolicy/Resource`,
+      `/${id}/NAlarmEmailFormatterRole/DefaultPolicy/Resource`,
+      `/${id}/NOnlinePlugStatusRole/DefaultPolicy/Resource`,
+      `/${id}/NPiPlugOnRole/DefaultPolicy/Resource`,
+    ], [{
+      id: 'AwsSolutions-IAM5',
+      reason: 'Log stream ARNs require logGroupArn:* suffix; PutMetricData does not support resource-level permissions (scoped by namespace condition)',
+    }]);
 
     // Setup Schedule to run Online Plug Status Lambda Function per cron schedule
     const onlineMetricSchedule = new cdk.aws_events.Rule(this, "NOnlineMetricRule", {schedule: cdk.aws_events.Schedule.cron({minute: "*/5"})});
@@ -44,24 +65,24 @@ export class NepenthesCDKStack extends cdk.Stack {
 
     // Setup SNS to alarm
     const nepenthesAlams = new NepenthesAlarms(this);
-    const alarmSNSTopic = new cdk.aws_sns.Topic(this, "NAlarmTopic");
+    const alarmSNSTopic = new cdk.aws_sns.Topic(this, "NAlarmTopic", { enforceSSL: true });
     alarmSNSTopic.addSubscription(new cdk.aws_sns_subscriptions.LambdaSubscription(lambdaFunctions.nepenthesPushoverFunction));
     nepenthesAlams.alarms.forEach((alarm) => alarm.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(alarmSNSTopic)));
 
     // Format alarm notifications for email delivery
-    const formattedAlarmSNSTopic = new cdk.aws_sns.Topic(this, "NFormattedAlarmTopic");
+    const formattedAlarmSNSTopic = new cdk.aws_sns.Topic(this, "NFormattedAlarmTopic", { enforceSSL: true });
     formattedAlarmSNSTopic.addSubscription(new cdk.aws_sns_subscriptions.EmailSubscription(EMAIL_ADDRESS));
     formattedAlarmSNSTopic.grantPublish(lambdaFunctions.nepenthesAlarmEmailFormatterFunction);
     lambdaFunctions.nepenthesAlarmEmailFormatterFunction.addEnvironment("FORMATTED_TOPIC_ARN", formattedAlarmSNSTopic.topicArn);
     alarmSNSTopic.addSubscription(new cdk.aws_sns_subscriptions.LambdaSubscription(lambdaFunctions.nepenthesAlarmEmailFormatterFunction));
 
     // Send recovery (OK) notifications via email only (not Pushover)
-    const okActionSNSTopic = new cdk.aws_sns.Topic(this, "NOkActionTopic");
+    const okActionSNSTopic = new cdk.aws_sns.Topic(this, "NOkActionTopic", { enforceSSL: true });
     okActionSNSTopic.addSubscription(new cdk.aws_sns_subscriptions.LambdaSubscription(lambdaFunctions.nepenthesAlarmEmailFormatterFunction));
     nepenthesAlams.alarms.forEach((alarm) => alarm.addOkAction(new cdk.aws_cloudwatch_actions.SnsAction(okActionSNSTopic)));
 
     // Setup trigger lambda when N.Pi is offline for 5 minutes
-    const nPiInvalidLowSevSNSTopic = new cdk.aws_sns.Topic(this, "NPiInvalidLowSevTopic");
+    const nPiInvalidLowSevSNSTopic = new cdk.aws_sns.Topic(this, "NPiInvalidLowSevTopic", { enforceSSL: true });
     nPiInvalidLowSevSNSTopic.addSubscription(new cdk.aws_sns_subscriptions.LambdaSubscription(lambdaFunctions.nepenthesPiPlugOnFunction));
     nepenthesAlams.nPiInvalidLowSevAlarm.addAlarmAction(new cdk.aws_cloudwatch_actions.SnsAction(nPiInvalidLowSevSNSTopic));
 

--- a/test/nepenthes_cdk.test.ts
+++ b/test/nepenthes_cdk.test.ts
@@ -24,11 +24,11 @@ describe('Constants', () => {
 });
 
 describe('Lambda Functions', () => {
-    test('creates 5 Lambda functions with Python 3.12 runtime', () => {
+    test('creates 5 Lambda functions with Python 3.14 runtime', () => {
         template.resourceCountIs('AWS::Lambda::Function', 5);
 
         template.hasResourceProperties('AWS::Lambda::Function', {
-            Runtime: 'python3.12',
+            Runtime: 'python3.14',
         });
     });
 


### PR DESCRIPTION
## Summary
Fixes the CI deploy failures caused by cdk-nag `AwsSolutionsChecks` emitting errors during `cdk diff`.

All 4 finding types are addressed at the source rather than blanket-suppressed:

- **AwsSolutions-SNS3**: Added `enforceSSL: true` to all 4 SNS topics (defense-in-depth SSL enforcement)
- **AwsSolutions-L1**: Upgraded Lambda runtime from Python 3.12 to **3.14** (latest known to CDK)
- **AwsSolutions-IAM4**: Replaced the `AWSLambdaBasicExecutionRole` managed policy with custom IAM roles using inline policies scoped to each function's specific log group ARN
- **AwsSolutions-IAM5**: Added `cloudwatch:namespace` condition to `PutMetricData` policy; the `Resource: *` is suppressed only because CloudWatch metrics are not ARN-addressable (AWS API limitation)

## Test plan
- [x] `cdk synth` passes with zero cdk-nag errors
- [x] 23 CDK tests pass (runtime assertion updated to python3.14)
- [x] 65 Python tests pass (99.58% coverage)
- [ ] Verify CI pipeline passes after merge
- [ ] Verify Lambda functions work correctly on Python 3.14 after deploy

https://claude.ai/code/session_0164rVH1oNDYAiwbzRpZEQnV