### PR TITLE
Centralize device names into constants.ts

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -28,3 +28,9 @@ export const THRESHOLD_TEMPERATURE_HIGH = 26.0;
 export const THRESHOLD_TEMPERATURE_LOW = 10.0;
 export const THRESHOLD_HUMIDITY_LOW = 50.0;
 export const THRESHOLD_BATTERY_LOW = 5;
+
+// Device names (single source of truth for alarms, dashboard, and Lambda config)
+export const METERS = ["N. Meter 1", "N. Meter 2"];
+export const PLUGS = ["N.Pi", "N.Fan"];
+export const PI_PLUG_NAME = "N.Pi";
+export const FAN_PLUG_NAME = "N.Fan";

--- a/lib/nepenthes-alarms.ts
+++ b/lib/nepenthes-alarms.ts
@@ -3,7 +3,8 @@ import { Construct } from 'constructs';
 import { METRIC_NAMESPACE, METRIC_NAME_BATTERY, METRIC_NAME_HEARTBEAT, METRIC_NAME_HUMIDITY,
          METRIC_NAME_POWER, METRIC_NAME_SWITCH, METRIC_NAME_TEMPERATURE,
          THRESHOLD_TEMPERATURE_HIGH, THRESHOLD_TEMPERATURE_LOW,
-         THRESHOLD_HUMIDITY_LOW, THRESHOLD_BATTERY_LOW } from './constants';
+         THRESHOLD_HUMIDITY_LOW, THRESHOLD_BATTERY_LOW,
+         METERS, PI_PLUG_NAME, FAN_PLUG_NAME } from './constants';
 
 
 export class NepenthesAlarms {
@@ -26,8 +27,6 @@ export class NepenthesAlarms {
                 statistic: cdk.aws_cloudwatch.Stats.MAXIMUM,
             }),
         });
-
-        const METERS = ["N. Meter 1", "N. Meter 2"]
 
         const highTemperatureAlarms = METERS.map((meterAlias) => {
             const escapedAlias = meterAlias.replace(/ /g, "")
@@ -124,7 +123,7 @@ export class NepenthesAlarms {
                 namespace: METRIC_NAMESPACE,
                 metricName: METRIC_NAME_SWITCH,
                 dimensionsMap: {
-                    "Plug": "N.Pi",
+                    "Plug": PI_PLUG_NAME,
                 },
                 period: cdk.Duration.minutes(5),
                 statistic: cdk.aws_cloudwatch.Stats.MAXIMUM,
@@ -142,7 +141,7 @@ export class NepenthesAlarms {
                 namespace: METRIC_NAMESPACE,
                 metricName: METRIC_NAME_POWER,
                 dimensionsMap: {
-                    "Plug": "N.Fan",
+                    "Plug": FAN_PLUG_NAME,
                 },
                 period: cdk.Duration.minutes(5),
                 statistic: cdk.aws_cloudwatch.Stats.MAXIMUM,
@@ -160,7 +159,7 @@ export class NepenthesAlarms {
                 namespace: METRIC_NAMESPACE,
                 metricName: METRIC_NAME_SWITCH,
                 dimensionsMap: {
-                    "Plug": "N.Fan",
+                    "Plug": FAN_PLUG_NAME,
                 },
                 period: cdk.Duration.minutes(5),
                 statistic: cdk.aws_cloudwatch.Stats.MAXIMUM,
@@ -189,7 +188,7 @@ export class NepenthesAlarms {
                 namespace: METRIC_NAMESPACE,
                 metricName: METRIC_NAME_SWITCH,
                 dimensionsMap: {
-                    "Plug": "N.Pi",
+                    "Plug": PI_PLUG_NAME,
                 },
                 period: cdk.Duration.minutes(5),
                 statistic: cdk.aws_cloudwatch.Stats.MAXIMUM,

--- a/lib/nepenthes-dashboard.ts
+++ b/lib/nepenthes-dashboard.ts
@@ -1,16 +1,14 @@
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { METRIC_NAMESPACE, THRESHOLD_TEMPERATURE_HIGH, THRESHOLD_TEMPERATURE_LOW,
-         THRESHOLD_HUMIDITY_LOW, THRESHOLD_BATTERY_LOW } from './constants';
+         THRESHOLD_HUMIDITY_LOW, THRESHOLD_BATTERY_LOW,
+         METERS, PLUGS, FAN_PLUG_NAME } from './constants';
 
 export class NepenthesDashboard {
     constructor(scope: Construct, alarms: cdk.aws_cloudwatch.AlarmBase[]) {
         const dashboard = new cdk.aws_cloudwatch.Dashboard(scope, 'NHomeDashboard', {
             dashboardName: 'NHome-Nepenthes',
         });
-
-        const METERS = ['N. Meter 1', 'N. Meter 2'];
-        const PLUGS = ['N.Pi', 'N.Fan'];
 
         // Temperature graph with alarm thresholds
         const temperatureWidget = new cdk.aws_cloudwatch.GraphWidget({
@@ -101,10 +99,10 @@ export class NepenthesDashboard {
             left: [new cdk.aws_cloudwatch.Metric({
                 namespace: METRIC_NAMESPACE,
                 metricName: 'Power',
-                dimensionsMap: { Plug: 'N.Fan' },
+                dimensionsMap: { Plug: FAN_PLUG_NAME },
                 period: cdk.Duration.minutes(5),
                 statistic: cdk.aws_cloudwatch.Stats.AVERAGE,
-                label: 'N.Fan',
+                label: FAN_PLUG_NAME,
             })],
             width: 6,
             height: 3,


### PR DESCRIPTION
## Summary
- Move `METERS` and `PLUGS` arrays, plus `PI_PLUG_NAME` and `FAN_PLUG_NAME`, to `constants.ts` as the single source of truth
- Update `nepenthes-alarms.ts` and `nepenthes-dashboard.ts` to import from constants instead of defining local copies
- Eliminates the risk of device name drift between alarms and dashboard

## Test plan
- [ ] Verify `npx jest` passes (all alarm/dashboard tests)
- [ ] Verify `cdk diff` shows no infrastructure changes (purely a refactor)

https://claude.ai/code/session_0164rVH1oNDYAiwbzRpZEQnV