### PR TITLE
Centralize alarm thresholds into constants.ts

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -22,3 +22,9 @@ export const METRIC_NAME_BATTERY = "Battery";
 export const METRIC_NAME_VALID = "Valid";
 export const METRIC_NAME_SWITCH = "Switch";
 export const METRIC_NAME_POWER = "Power";
+
+// Alarm thresholds (single source of truth for alarms and dashboard annotations)
+export const THRESHOLD_TEMPERATURE_HIGH = 26.0;
+export const THRESHOLD_TEMPERATURE_LOW = 10.0;
+export const THRESHOLD_HUMIDITY_LOW = 50.0;
+export const THRESHOLD_BATTERY_LOW = 5;

--- a/lib/nepenthes-alarms.ts
+++ b/lib/nepenthes-alarms.ts
@@ -1,7 +1,9 @@
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { METRIC_NAMESPACE, METRIC_NAME_BATTERY, METRIC_NAME_HEARTBEAT, METRIC_NAME_HUMIDITY,
-         METRIC_NAME_POWER, METRIC_NAME_SWITCH, METRIC_NAME_TEMPERATURE } from './constants';
+         METRIC_NAME_POWER, METRIC_NAME_SWITCH, METRIC_NAME_TEMPERATURE,
+         THRESHOLD_TEMPERATURE_HIGH, THRESHOLD_TEMPERATURE_LOW,
+         THRESHOLD_HUMIDITY_LOW, THRESHOLD_BATTERY_LOW } from './constants';
 
 
 export class NepenthesAlarms {
@@ -35,7 +37,7 @@ export class NepenthesAlarms {
                 evaluationPeriods: 30,
                 treatMissingData: cdk.aws_cloudwatch.TreatMissingData.IGNORE,
                 comparisonOperator:  cdk.aws_cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-                threshold: 26.0,
+                threshold: THRESHOLD_TEMPERATURE_HIGH,
                 metric: new cdk.aws_cloudwatch.Metric({
                     namespace: METRIC_NAMESPACE,
                     metricName: METRIC_NAME_TEMPERATURE,
@@ -56,7 +58,7 @@ export class NepenthesAlarms {
                 evaluationPeriods: 30,
                 treatMissingData: cdk.aws_cloudwatch.TreatMissingData.IGNORE,
                 comparisonOperator:  cdk.aws_cloudwatch.ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
-                threshold: 10.0,
+                threshold: THRESHOLD_TEMPERATURE_LOW,
                 metric: new cdk.aws_cloudwatch.Metric({
                     namespace: METRIC_NAMESPACE,
                     metricName: METRIC_NAME_TEMPERATURE,
@@ -77,7 +79,7 @@ export class NepenthesAlarms {
                 evaluationPeriods: 30,
                 treatMissingData: cdk.aws_cloudwatch.TreatMissingData.IGNORE,
                 comparisonOperator:  cdk.aws_cloudwatch.ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
-                threshold: 50.0,
+                threshold: THRESHOLD_HUMIDITY_LOW,
                 metric: new cdk.aws_cloudwatch.Metric({
                     namespace: METRIC_NAMESPACE,
                     metricName: METRIC_NAME_HUMIDITY,
@@ -98,7 +100,7 @@ export class NepenthesAlarms {
                 evaluationPeriods: 24,
                 treatMissingData: cdk.aws_cloudwatch.TreatMissingData.IGNORE,
                 comparisonOperator:  cdk.aws_cloudwatch.ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
-                threshold: 5,
+                threshold: THRESHOLD_BATTERY_LOW,
                 metric: new cdk.aws_cloudwatch.Metric({
                     namespace: METRIC_NAMESPACE,
                     metricName: METRIC_NAME_BATTERY,

--- a/lib/nepenthes-dashboard.ts
+++ b/lib/nepenthes-dashboard.ts
@@ -1,6 +1,7 @@
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-import { METRIC_NAMESPACE } from './constants';
+import { METRIC_NAMESPACE, THRESHOLD_TEMPERATURE_HIGH, THRESHOLD_TEMPERATURE_LOW,
+         THRESHOLD_HUMIDITY_LOW, THRESHOLD_BATTERY_LOW } from './constants';
 
 export class NepenthesDashboard {
     constructor(scope: Construct) {
@@ -23,8 +24,8 @@ export class NepenthesDashboard {
                 label: meter,
             })),
             leftAnnotations: [
-                { value: 26, color: '#d62728', label: 'High threshold' },
-                { value: 10, color: '#1f77b4', label: 'Low threshold' },
+                { value: THRESHOLD_TEMPERATURE_HIGH, color: '#d62728', label: 'High threshold' },
+                { value: THRESHOLD_TEMPERATURE_LOW, color: '#1f77b4', label: 'Low threshold' },
             ],
             width: 12,
             height: 6,
@@ -42,7 +43,7 @@ export class NepenthesDashboard {
                 label: meter,
             })),
             leftAnnotations: [
-                { value: 50, color: '#ff7f0e', label: 'Low threshold' },
+                { value: THRESHOLD_HUMIDITY_LOW, color: '#ff7f0e', label: 'Low threshold' },
             ],
             width: 12,
             height: 6,
@@ -60,7 +61,7 @@ export class NepenthesDashboard {
                 label: meter,
             })),
             leftAnnotations: [
-                { value: 5, color: '#d62728', label: 'Low threshold' },
+                { value: THRESHOLD_BATTERY_LOW, color: '#d62728', label: 'Low threshold' },
             ],
             width: 12,
             height: 6,


### PR DESCRIPTION
## Summary
- Add `THRESHOLD_TEMPERATURE_HIGH` (26°C), `THRESHOLD_TEMPERATURE_LOW` (10°C), `THRESHOLD_HUMIDITY_LOW` (50%), and `THRESHOLD_BATTERY_LOW` (5%) to `constants.ts`
- Update `nepenthes-alarms.ts` to use threshold constants instead of hardcoded values
- Update `nepenthes-dashboard.ts` annotations to reference the same constants
- Ensures alarm thresholds and dashboard annotation lines can never drift out of sync

## Test plan
- [ ] Verify `npx jest` passes (all alarm/dashboard tests)
- [ ] Verify `cdk diff` shows no infrastructure changes (purely a refactor)

https://claude.ai/code/session_0164rVH1oNDYAiwbzRpZEQnV