### PR TITLE
Replace print() with structured logging in Lambda functions

### DIFF
--- a/lambda/cloudwatch.py
+++ b/lambda/cloudwatch.py
@@ -1,5 +1,8 @@
 import boto3
 import datetime
+import logging
+
+logger = logging.getLogger(__name__)
 
 cloud_watch = boto3.client('cloudwatch')
 
@@ -8,7 +11,6 @@ def put_cloudwatch(metricNamespace, metricName, value, unit, timestamp=None, dim
     value = (1 if value else 0) if type(value) == bool else value
     if not timestamp:
         timestamp = datetime.datetime.now()
-    # print(metricName + ", " + str(value) + ", " + unit + ", " + timestamp.isoformat())
     try:
         data = {
             "MetricName" : metricName,
@@ -23,5 +25,5 @@ def put_cloudwatch(metricNamespace, metricName, value, unit, timestamp=None, dim
             MetricData = [data]
         )
     except Exception as e:
-        print(e)
+        logger.error("Failed to put metric %s: %s", metricName, e)
         raise

--- a/lambda/nepenthes_alarm_email_formatter.py
+++ b/lambda/nepenthes_alarm_email_formatter.py
@@ -1,15 +1,18 @@
 import json
+import logging
 import os
 import boto3
 
 from alarm_formatter import format_alarm
+
+logger = logging.getLogger(__name__)
 
 FORMATTED_TOPIC_ARN = os.environ["FORMATTED_TOPIC_ARN"]
 sns_client = boto3.client("sns")
 
 
 def lambda_handler(event, _):
-    print("Event: " + str(event))
+    logger.info("Event: %s", event)
 
     record = event.get("Records", [{}])[0]
     formatted = format_alarm(record)

--- a/lambda/nepenthes_log_puller.py
+++ b/lambda/nepenthes_log_puller.py
@@ -1,11 +1,14 @@
 import datetime
+import logging
 import os
 from cloudwatch import put_cloudwatch
 
+logger = logging.getLogger(__name__)
+
 METRIC_NAMESPACE = os.environ["METRIC_NAMESPACE"]
-    
+
 def lambda_handler(event, context):
-    print("Event: " + str(event))
+    logger.info("Event: %s", event)
     meters = event.get("meters", {}).get("v0", {})
     plugs = event.get("plugs", {}).get("v0", {})
     should_heartbeat = event["should_heartbeat"]

--- a/lambda/nepenthes_pushover.py
+++ b/lambda/nepenthes_pushover.py
@@ -1,8 +1,11 @@
 import json
+import logging
 import os
 import requests
 
 from alarm_formatter import format_alarm
+
+logger = logging.getLogger(__name__)
 
 PUSHOVER_API_KEY = os.environ["PUSHOVER_API_KEY"]
 PAGEE_USER_KEY = os.environ["PAGEE_USER_KEY"]
@@ -10,14 +13,14 @@ API_URL = "https://api.pushover.net/1/messages.json"
 
 
 def lambda_handler(event, _):
-    print("Event: " + str(event))
+    logger.info("Event: %s", event)
 
     record = event.get("Records", [{}])[0]
     formatted = format_alarm(record)
 
     # Skip sending Pushover for OK (recovery) state transitions
     if formatted.get("state") == "OK":
-        print("Skipping Pushover for OK state")
+        logger.info("Skipping Pushover for OK state")
         return {"statusCode": 200, "body": "skipped OK state"}
 
     headers = {


### PR DESCRIPTION
## Summary
- Replace all `print()` calls with Python's `logging` module across 6 Lambda files
- Use `logger.info()` for normal flow (events, device IDs, responses)
- Use `logger.warning()` for retry attempts (cache invalidation)
- Use `logger.error()` for failures (exceptions, API errors)
- AWS Lambda runtime integrates with the logging module to provide structured output with timestamps, log levels, and request IDs in CloudWatch Logs

## Files changed
- `cloudwatch.py` - error logging on PutMetricData failures
- `nepenthes_log_puller.py` - event logging
- `nepenthes_pushover.py` - event and skip-OK logging
- `nepenthes_alarm_email_formatter.py` - event logging
- `nepenthes_online_plug_status.py` - device status flow + error logging
- `nepenthes_pi_plug_on.py` - plug recovery flow + error logging

## Test plan
- [ ] Verify all 65 Python tests pass (`uv run pytest tests/ -v`)
- [ ] Verify coverage remains >= 80% (currently 99.60%)

https://claude.ai/code/session_0164rVH1oNDYAiwbzRpZEQnV