### PR TITLE
Add exponential backoff to SwitchBot API retries

### DIFF
--- a/lambda/nepenthes_online_plug_status.py
+++ b/lambda/nepenthes_online_plug_status.py
@@ -1,7 +1,7 @@
 import os
 import requests
 from cloudwatch import put_cloudwatch
-from switchbot import build_headers, get_device_id, invalidate_device_id, DEVICE_STATUS_ENDPOINT_FORMAT
+from switchbot import build_headers, call_with_retry, DEVICE_STATUS_ENDPOINT_FORMAT
 
 SB_TOKEN = os.environ["SB_TOKEN"]
 SB_SECRET_KEY = os.environ["SB_SECRET_KEY"]
@@ -23,19 +23,8 @@ def lambda_handler(event, context):
             "Value": device_name.replace(" ", ""),
         }]
         try:
-            device_id = get_device_id(SB_TOKEN, SB_SECRET_KEY, device_name)
-            print("{} device id: {}".format(device_name, device_id))
-            try:
-                response = _get_device_status(device_id)
-            except Exception:
-                print("Retrying with fresh device id for {}".format(device_name))
-                invalidate_device_id(device_name)
-                device_id = get_device_id(SB_TOKEN, SB_SECRET_KEY, device_name)
-                print("{} device id (refreshed): {}".format(device_name, device_id))
-                response = _get_device_status(device_id)
-            print(response)
+            response = call_with_retry(SB_TOKEN, SB_SECRET_KEY, device_name, _get_device_status)
         except Exception as e:
-            print(e)
             put_cloudwatch(METRIC_NAMESPACE, "Valid", False, "None", dimensions=dimensions)
             raise e
         put_cloudwatch(METRIC_NAMESPACE, "Valid", True, "None", dimensions=dimensions)

--- a/lambda/tests/test_online_plug_status.py
+++ b/lambda/tests/test_online_plug_status.py
@@ -1,23 +1,19 @@
 import os
+import pytest
 from unittest.mock import patch, MagicMock
 
 os.environ["SB_TOKEN"] = "test-token"
 os.environ["SB_SECRET_KEY"] = "test-secret"
 os.environ["METRIC_NAMESPACE"] = "TestNamespace"
 
-from nepenthes_online_plug_status import lambda_handler
+from nepenthes_online_plug_status import lambda_handler, _get_device_status
 
 
 class TestLambdaHandler:
     @patch("nepenthes_online_plug_status.put_cloudwatch")
-    @patch("nepenthes_online_plug_status.get_device_id")
-    @patch("nepenthes_online_plug_status.requests.get")
-    def test_publishes_metrics_for_online_plug(self, mock_get, mock_get_id, mock_cw):
-        mock_get_id.return_value = "device-123"
-        mock_get.return_value.json.return_value = {
-            "statusCode": 100,
-            "body": {"power": "on", "electricCurrent": 5.2},
-        }
+    @patch("nepenthes_online_plug_status.call_with_retry")
+    def test_publishes_metrics_for_online_plug(self, mock_retry, mock_cw):
+        mock_retry.return_value = {"power": "on", "electricCurrent": 5.2}
 
         lambda_handler({}, None)
 
@@ -27,14 +23,9 @@ class TestLambdaHandler:
         assert "Power" in metric_names
 
     @patch("nepenthes_online_plug_status.put_cloudwatch")
-    @patch("nepenthes_online_plug_status.get_device_id")
-    @patch("nepenthes_online_plug_status.requests.get")
-    def test_publishes_zero_power_when_off(self, mock_get, mock_get_id, mock_cw):
-        mock_get_id.return_value = "device-123"
-        mock_get.return_value.json.return_value = {
-            "statusCode": 100,
-            "body": {"power": "off", "electricCurrent": 0},
-        }
+    @patch("nepenthes_online_plug_status.call_with_retry")
+    def test_publishes_zero_power_when_off(self, mock_retry, mock_cw):
+        mock_retry.return_value = {"power": "off", "electricCurrent": 0}
 
         lambda_handler({}, None)
 
@@ -42,25 +33,20 @@ class TestLambdaHandler:
         assert power_calls[0].args[2] == 0
 
     @patch("nepenthes_online_plug_status.put_cloudwatch")
-    @patch("nepenthes_online_plug_status.get_device_id")
-    @patch("nepenthes_online_plug_status.requests.get")
-    def test_retries_with_fresh_device_id(self, mock_get, mock_get_id, mock_cw):
-        mock_get_id.return_value = "device-123"
-        success = {"statusCode": 100, "body": {"power": "on", "electricCurrent": 1}}
-        # First call raises (triggers retry for device 1), rest succeed
-        mock_get.return_value.json.side_effect = [
-            RuntimeError("API error"), success, success,
-        ]
+    @patch("nepenthes_online_plug_status.call_with_retry")
+    def test_calls_retry_for_each_device(self, mock_retry, mock_cw):
+        mock_retry.return_value = {"power": "on", "electricCurrent": 1}
 
-        with patch("nepenthes_online_plug_status.invalidate_device_id") as mock_inv:
-            lambda_handler({}, None)
-            mock_inv.assert_called()
+        lambda_handler({}, None)
+
+        device_names = [c.args[2] for c in mock_retry.call_args_list]
+        assert "N. Pi" in device_names
+        assert "N. Fan" in device_names
 
     @patch("nepenthes_online_plug_status.put_cloudwatch")
-    @patch("nepenthes_online_plug_status.get_device_id")
-    @patch("nepenthes_online_plug_status.requests.get")
-    def test_publishes_valid_false_on_failure(self, mock_get, mock_get_id, mock_cw):
-        mock_get_id.side_effect = RuntimeError("Cannot find device")
+    @patch("nepenthes_online_plug_status.call_with_retry")
+    def test_publishes_valid_false_on_failure(self, mock_retry, mock_cw):
+        mock_retry.side_effect = RuntimeError("Cannot find device")
 
         try:
             lambda_handler({}, None)
@@ -69,3 +55,29 @@ class TestLambdaHandler:
 
         valid_calls = [c for c in mock_cw.call_args_list if c.args[1] == "Valid"]
         assert any(c.args[2] is False for c in valid_calls)
+
+
+class TestGetDeviceStatus:
+    @patch("nepenthes_online_plug_status.build_headers")
+    @patch("nepenthes_online_plug_status.requests.get")
+    def test_returns_response_body(self, mock_get, mock_headers):
+        mock_headers.return_value = {"Authorization": "tok"}
+        mock_get.return_value.json.return_value = {
+            "statusCode": 100,
+            "body": {"power": "on", "electricCurrent": 5.2},
+        }
+
+        result = _get_device_status("device-123")
+        assert result == {"power": "on", "electricCurrent": 5.2}
+
+    @patch("nepenthes_online_plug_status.build_headers")
+    @patch("nepenthes_online_plug_status.requests.get")
+    def test_raises_on_api_error(self, mock_get, mock_headers):
+        mock_headers.return_value = {"Authorization": "tok"}
+        mock_get.return_value.json.return_value = {
+            "statusCode": 190,
+            "body": {},
+        }
+
+        with pytest.raises(RuntimeError):
+            _get_device_status("device-123")

--- a/lambda/tests/test_pi_plug_on.py
+++ b/lambda/tests/test_pi_plug_on.py
@@ -1,65 +1,73 @@
 import os
+import pytest
 from unittest.mock import patch, MagicMock
 
 os.environ["SB_TOKEN"] = "test-token"
 os.environ["SB_SECRET_KEY"] = "test-secret"
 
-from nepenthes_pi_plug_on import lambda_handler
+from nepenthes_pi_plug_on import lambda_handler, _turn_plug_on
 
 
 class TestLambdaHandler:
-    @patch("nepenthes_pi_plug_on.get_device_id")
+    @patch("nepenthes_pi_plug_on.call_with_retry")
+    def test_returns_response_from_call_with_retry(self, mock_retry):
+        mock_retry.return_value = {"items": ["ok"]}
+
+        result = lambda_handler({}, None)
+
+        assert result == {"items": ["ok"]}
+
+    @patch("nepenthes_pi_plug_on.call_with_retry")
+    def test_passes_pi_device_name(self, mock_retry):
+        mock_retry.return_value = {"items": []}
+
+        lambda_handler({}, None)
+
+        assert mock_retry.call_args.args[2] == "N. Pi"
+
+    @patch("nepenthes_pi_plug_on.call_with_retry")
+    def test_passes_turn_plug_on_operation(self, mock_retry):
+        mock_retry.return_value = {"items": []}
+
+        lambda_handler({}, None)
+
+        # The 4th argument is the operation function
+        operation = mock_retry.call_args.args[3]
+        assert callable(operation)
+
+    @patch("nepenthes_pi_plug_on.call_with_retry")
+    def test_raises_when_retry_fails(self, mock_retry):
+        mock_retry.side_effect = RuntimeError("All retries failed")
+
+        with pytest.raises(RuntimeError, match="All retries failed"):
+            lambda_handler({}, None)
+
+
+class TestTurnPlugOn:
+    @patch("nepenthes_pi_plug_on.build_headers")
     @patch("nepenthes_pi_plug_on.requests.post")
-    def test_turns_plug_on(self, mock_post, mock_get_id):
-        mock_get_id.return_value = "device-123"
+    def test_sends_turn_on_command(self, mock_post, mock_headers):
+        mock_headers.return_value = {"Authorization": "tok"}
         mock_post.return_value.json.return_value = {
             "statusCode": 100,
             "body": {"items": []},
         }
 
-        result = lambda_handler({}, None)
+        result = _turn_plug_on("device-123")
 
         mock_post.assert_called_once()
         call_kwargs = mock_post.call_args.kwargs
         assert call_kwargs["json"]["command"] == "turnOn"
+        assert result == {"items": []}
 
-    @patch("nepenthes_pi_plug_on.get_device_id")
+    @patch("nepenthes_pi_plug_on.build_headers")
     @patch("nepenthes_pi_plug_on.requests.post")
-    def test_returns_response_body(self, mock_post, mock_get_id):
-        mock_get_id.return_value = "device-123"
-        mock_post.return_value.json.return_value = {
-            "statusCode": 100,
-            "body": {"items": ["ok"]},
-        }
-
-        result = lambda_handler({}, None)
-        assert result == {"items": ["ok"]}
-
-    @patch("nepenthes_pi_plug_on.invalidate_device_id")
-    @patch("nepenthes_pi_plug_on.get_device_id")
-    @patch("nepenthes_pi_plug_on.requests.post")
-    def test_retries_with_fresh_device_id(self, mock_post, mock_get_id, mock_inv):
-        mock_get_id.return_value = "device-123"
-        # First call fails, second succeeds
-        mock_post.return_value.json.side_effect = [
-            RuntimeError("API error"),
-            {"statusCode": 100, "body": {"items": []}},
-        ]
-
-        lambda_handler({}, None)
-        mock_inv.assert_called_once_with("N. Pi")
-
-    @patch("nepenthes_pi_plug_on.get_device_id")
-    @patch("nepenthes_pi_plug_on.requests.post")
-    def test_raises_on_api_error(self, mock_post, mock_get_id):
-        mock_get_id.return_value = "device-123"
+    def test_raises_on_api_error(self, mock_post, mock_headers):
+        mock_headers.return_value = {"Authorization": "tok"}
         mock_post.return_value.json.return_value = {
             "statusCode": 190,
             "body": {},
         }
 
-        try:
-            lambda_handler({}, None)
-            assert False, "Expected RuntimeError"
-        except RuntimeError:
-            pass
+        with pytest.raises(RuntimeError):
+            _turn_plug_on("device-123")


### PR DESCRIPTION
## Summary
- Add `call_with_retry()` to `switchbot.py` that handles retry-with-cache-invalidation using exponential backoff (0.5s, 1.0s delays, 2 retries by default)
- Refactor `nepenthes_online_plug_status.py` and `nepenthes_pi_plug_on.py` to use `call_with_retry()` instead of manual nested try/except retry logic
- Simplifies both handlers significantly (pi_plug_on handler is now a single line)

## Behavior
1. First attempt uses the cached device ID
2. On failure: waits 0.5s, invalidates cache, retries with fresh device ID
3. On second failure: waits 1.0s, invalidates cache, retries again
4. On third failure: raises the exception

## Test plan
- [ ] Verify all 74 Python tests pass (`uv run pytest tests/ -v`)
- [ ] Verify 100% test coverage
- [ ] 5 new tests for `call_with_retry`: success on first attempt, retry-and-succeed, all-retries-exhausted, exponential backoff delays, cache invalidation before retry

https://claude.ai/code/session_0164rVH1oNDYAiwbzRpZEQnV