### PR TITLE
CI: Run tests on pull requests and guard deploy job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 permissions:
   id-token: write
@@ -50,6 +53,7 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     needs: test
+    if: github.ref == 'refs/heads/main'
     env:
       DOTENV_PRIVATE_KEY: ${{ secrets.DOTENV_PRIVATE_KEY }}
     steps:


### PR DESCRIPTION
## Summary
Updated the GitHub Actions deployment workflow to run tests on pull requests and added a guard condition to prevent deployments from running on non-main branches.

## Key Changes
- Added `pull_request` trigger for the `main` branch to ensure tests run on all PRs
- Added `if: github.ref == 'refs/heads/main'` condition to the deploy job to ensure deployments only occur when pushing directly to the main branch, not on pull requests

## Implementation Details
These changes improve the CI/CD safety by:
1. Validating code quality through automated tests on every pull request before merge
2. Preventing accidental deployments from feature branches or pull request workflows
3. Ensuring the deploy job only executes on direct pushes to main, maintaining a clear separation between testing and deployment triggers

https://claude.ai/code/session_01SvG2fCTGSF1i8zMwBrqgAE